### PR TITLE
Initial changes to rename project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,5 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.0.1](https://github.com/git-afsantos/bake-a-py/releases/tag/v0.0.1) - 2021-12-16
-### Added
-- Support for type checking with `mypy`.
-- Support for code style with `flake8`, `black` and `isort`.
-- Configuration for `pre-commit` hooks.
-- Example `main` entry point.
-- GitHub workflows.
-
-### Changed
-- Refining package structure.
-
-### Fixed
-- Fixed an issue that prevented `pip install -e .` from working.
-
-## [0.0.0](https://github.com/git-afsantos/bake-a-py/releases/tag/v0.0.0) - 2021-12-09
+## [0.0.0](https://github.com/git-afsantos/ros-modex/releases/tag/v0.0.0) - 2021-12-17
 Repository creation.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,12 @@
-# Bake a Py
+# ROS Model Extractor (WIP)
 
-This project provides a template from which you can create your own Python packages and projects.
-It uses modern tools and conventions to ensure a good development experience.
+This project provides a model extraction tool for ROS Launch applications.
+It should be able to read launch files, interpret them, and build a model of the expected architecture of the ROS system at runtime.
 
 - [Package Structure](#package-structure)
-- [GitHub Features](#github-features)
 - [Tooling](#tooling)
 
 ## Package Structure
-
-Package structure was inspired by various templates and recommended best practices, such as:
-
-- https://github.com/TezRomacH/python-package-template
-- https://github.com/pyscaffold/pyscaffold
-- https://github.com/f4str/python-package-template
-- https://github.com/audreyfeldroy/cookiecutter-pypackage
-- https://github.com/ionelmc/python-nameless
 
 It provides a `src` directory, under which your own packages sit. Example files for `__init__.py`, `__main__.py` and `cli.py` are already provided.
 
@@ -28,18 +19,6 @@ To start your new project, you should change its name, URL and metadata details 
 3. `setup.py`
 4. `tests/*.py`
 5. `src/*`
-
-## GitHub Features
-
-The `.github` directory comes with a number of files to configure certain GitHub features.
-
-- Various Issue templates can be found under `ISSUE_TEMPLATE`.
-- A Pull Request template can be found at `PULL_REQUEST_TEMPLATE.md`.
-- Automatically mark issues as stale after a period of inactivity. The configuration file can be found at `.stale.yml`.
-- Keep package dependencies up to date with Dependabot. The configuration file can be found at `dependabot.yml`.
-- Keep Release Drafts automatically up to date with Pull Requests, using the [Release Drafter GitHub Action](https://github.com/marketplace/actions/release-drafter). The configuration file can be found at `release-drafter.yml` and the workflow at `workflows/release-drafter.yml`.
-- Automatic package building and publishing when pushing a new version tag to `main`. The workflow can be found at `workflows/publish-package.yml`.
-- Code quality and security analysis with CodeQL. The workflow can be found at `workflows/codeql-analysis.yml`.
 
 ## Tooling
 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ from setuptools import find_packages, setup
 # Constants
 ###############################################################################
 
-PROJECT = 'bake-a-py'
-PYTHON_PKG = 'bakeapy'
+PROJECT = 'ros-modex'
+PYTHON_PKG = 'rosmodex'
 HERE = Path(__file__).parent
 
 ###############################################################################
@@ -39,14 +39,14 @@ setup(
         'local_scheme': 'dirty-tag',
         'fallback_version': '0.1.0',
     },
-    description='Variability analysis tool for ROS systems',
+    description='A model extraction and analysis tool for ROS systems',
     long_description=read('README.md'),
     long_description_content_type='text/markdown',
     url=f'https://github.com/git-afsantos/{PROJECT}',
     author='André Santos',
     author_email='haros.framework@gmail.com',
     license='MIT',
-    keywords='ros, variability, software product lines, feature models',
+    keywords='ros, variability, model extraction, feature models',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
     include_package_data=True,

--- a/src/rosmodex/__init__.py
+++ b/src/rosmodex/__init__.py
@@ -12,7 +12,7 @@ from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 ###############################################################################
 
 try:
-    __version__ = version('bakeapy')
+    __version__ = version('rosmodex')
 except PackageNotFoundError:  # pragma: no cover
     # package is not installed
     __version__ = 'unknown'

--- a/src/rosmodex/__main__.py
+++ b/src/rosmodex/__main__.py
@@ -17,7 +17,7 @@ Why does this file exist, and why __main__? For more info, read:
 
 import sys
 
-from bakeapy.cli import main
+from rosmodex.cli import main
 
 ###############################################################################
 # Entry Point

--- a/src/rosmodex/cli.py
+++ b/src/rosmodex/cli.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Optional
 import argparse
 import sys
 
-from bakeapy import __version__ as current_version
+from rosmodex import __version__ as current_version
 
 ###############################################################################
 # Argument Parsing

--- a/tests/test_pkg_import.py
+++ b/tests/test_pkg_import.py
@@ -5,7 +5,7 @@
 # Imports
 ###############################################################################
 
-import bakeapy
+import rosmodex
 
 ###############################################################################
 # Tests
@@ -17,6 +17,6 @@ def test_import_was_ok():
 
 
 def test_pkg_has_version():
-    assert hasattr(bakeapy, '__version__')
-    assert isinstance(bakeapy.__version__, str)
-    assert bakeapy.__version__ != ''
+    assert hasattr(rosmodex, '__version__')
+    assert isinstance(rosmodex.__version__, str)
+    assert rosmodex.__version__ != ''


### PR DESCRIPTION
## Description

This PR changes references to the default project name, `bake-a-py`, to use its own name, `ros-modex`.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :memo: Examples / docs / tutorials / dependencies update
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue)
- [ ] :sparkles: Improvement (non-breaking change which improves an existing feature)
- [ ] :package: New feature (non-breaking change which adds functionality)
- [x] :boom: Breaking change (fix or feature that would cause existing functionality to change)
- [ ] :closed_lock_with_key: Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

This pull request complies with the conduct and contribution guidelines of this repository.

- [x] Type checking passes with `tox -e typecheck`.
- [x] Coding style passes with `tox -e lint`.
- [x] New code is covered by new or existing tests.
- [x] All tests pass with `tox`.
- [x] New code is documented.
